### PR TITLE
Test namespace

### DIFF
--- a/gen_context.py
+++ b/gen_context.py
@@ -1,0 +1,40 @@
+"""\
+Parse a CSV namespace and generate the corresponding JSON-LD context.
+"""
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+
+RO_CRATE_VERSION = "1.1"
+RO_CRATE_CONTEXT = f"https://w3id.org/ro/crate/{RO_CRATE_VERSION}/context"
+RO_TERMS_PREFIX = "https://w3id.org/ro/terms"
+VOCAB_FN = "vocabulary.csv"
+
+
+def build_context(namespace, vocab_path):
+    add_terms = {}
+    with open(vocab_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            k = row["term"]
+            add_terms[k] = f"{RO_TERMS_PREFIX}/{namespace}#{k}"
+    return [RO_CRATE_CONTEXT, add_terms]
+
+
+def main(args):
+    ns_dir = Path(args.ns_dir)
+    vocab_path = ns_dir / VOCAB_FN
+    if not vocab_path.is_file():
+        raise RuntimeError(f"{vocab_path} not found")
+    context = build_context(ns_dir.name, vocab_path)
+    print(json.dumps(context, indent=4, sort_keys=False))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("ns_dir", metavar="NAMESPACE", help="namespace dir")
+    main(parser.parse_args(sys.argv[1:]))

--- a/gen_context.py
+++ b/gen_context.py
@@ -10,19 +10,19 @@ from pathlib import Path
 
 
 RO_CRATE_VERSION = "1.1"
-RO_CRATE_CONTEXT = f"https://w3id.org/ro/crate/{RO_CRATE_VERSION}/context"
 RO_TERMS_PREFIX = "https://w3id.org/ro/terms"
 VOCAB_FN = "vocabulary.csv"
 
 
-def build_context(namespace, vocab_path):
+def build_context(namespace, vocab_path, ro_crate_version=RO_CRATE_VERSION):
+    ro_crate_context = f"https://w3id.org/ro/crate/{ro_crate_version}/context"
     add_terms = {}
     with open(vocab_path, newline="") as f:
         reader = csv.DictReader(f)
         for row in reader:
             k = row["term"]
             add_terms[k] = f"{RO_TERMS_PREFIX}/{namespace}#{k}"
-    return [RO_CRATE_CONTEXT, add_terms]
+    return [ro_crate_context, add_terms]
 
 
 def main(args):
@@ -30,11 +30,14 @@ def main(args):
     vocab_path = ns_dir / VOCAB_FN
     if not vocab_path.is_file():
         raise RuntimeError(f"{vocab_path} not found")
-    context = build_context(ns_dir.name, vocab_path)
+    context = build_context(ns_dir.name, vocab_path,
+                            ro_crate_version=args.ro_crate_version)
     print(json.dumps(context, indent=4, sort_keys=False))
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("ns_dir", metavar="NAMESPACE", help="namespace dir")
+    parser.add_argument("-v", "--ro-crate-version", metavar="string",
+                        default=RO_CRATE_VERSION, help="RO-Crate version")
     main(parser.parse_args(sys.argv[1:]))

--- a/test/readme.md
+++ b/test/readme.md
@@ -1,0 +1,12 @@
+### Test namespace
+
+**WORK IN PROGRESS**
+
+An example namespace for workflow testing metadata.
+
+See https://github.com/crs4/life_monitor/wiki/Test-Metadata-Draft-Spec.
+
+Maintainer: 
+- Simone Leo (@simleo)
+- Marco Enrico Piras (@kikkomep)
+- Luca Pireddu (@ilveroluca)

--- a/test/test-metadata.json
+++ b/test/test-metadata.json
@@ -1,0 +1,66 @@
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "TestSuite": "https://w3id.org/ro/terms/test#TestSuite",
+            "TestInstance": "https://w3id.org/ro/terms/test#TestInstance",
+            "TestService": "https://w3id.org/ro/terms/test#TestService",
+            "TestDefinition": "https://w3id.org/ro/terms/test#TestDefinition",
+            "instance": "https://w3id.org/ro/terms/test#instance",
+            "runsOn": "https://w3id.org/ro/terms/test#runsOn",
+            "resource": "https://w3id.org/ro/terms/test#resource",
+            "definition": "https://w3id.org/ro/terms/test#definition"
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "#test1",
+            "name": "test1",
+            "@type": "TestSuite",
+            "instance": [
+                {"@id": "#test1_1"},
+                {"@id": "#test1_2"}
+            ],
+            "definition": {
+                "@id": "test2/someworkflow-test.yml",
+                "@type": "TestDefinition",
+                "conformsTo": {"@id": "#planemo"}
+            }
+        },
+        {
+            "@id": "#test1_1",
+            "name": "test1_1",
+            "@type": "TestInstance",
+            "runsOn": {"@id": "#jenkins"},
+            "url": "http://example.org/jenkins",
+            "resource": "job/tests/"
+        },
+        {
+            "@id": "#test1_2",
+            "name": "test1_2",
+            "@type": "TestInstance",
+            "runsOn": {"@id": "#travis"},
+            "url": "https://example.org/travis",
+            "resource": "github/acme/foobar/builds/"
+        },
+        {
+            "@id": "#jenkins",
+            "@type": "TestService",
+            "name": "Jenkins",
+            "url": {"@id": "https://www.jenkins.io"}
+        },
+        {
+            "@id": "#travis",
+            "@type": "TestService",
+            "name": "Travis CI",
+            "url": {"@id": "https://travis-ci.org"}
+        },
+        {
+            "@id": "#planemo",
+            "@type": "SoftwareApplication",
+            "name": "Planemo",
+            "url": {"@id": "https://github.com/galaxyproject/planemo"},
+            "softwareVersion": ">=0.70"
+        }
+    ]
+}

--- a/test/vocabulary.csv
+++ b/test/vocabulary.csv
@@ -1,6 +1,6 @@
 term,type,label,description,domain,range
-TestSuite,Class,test suite,A test suite for a computational workflow,,
-TestInstance,Class,test instance,A specific instance of a test suite,,
+TestSuite,Class,test suite,A set of tests for a computational workflow,,
+TestInstance,Class,test instance,A specific project to execute a test suite on a test service,,
 TestService,Class,test service,A software service where tests can be run,,
 TestDefinition,Class,test definition,A set of metadata that describes how to run the test,,
 instance,Property,instance,Instances of a test suite,TestSuite,TestInstance

--- a/test/vocabulary.csv
+++ b/test/vocabulary.csv
@@ -1,0 +1,17 @@
+term,type,label,description,domain,range
+Test,Class,Test,A test suite for a scientific workflow,,
+Instance,Class,Instance,A specific instance of a test suite,,
+Service,Class,Service,A Continuous Integration service where tests can be run,,
+Engine,Class,Engine,A workflow testing engine,,
+Definition,Class,Definition,A test definition (engine and configuration),,
+test,Property,test,Test suites for a workflow,Test,Test
+instance,Property,instance,Instances of a test suite,Test,Instance
+service,Property,service,Service where the test is run,Test,Service
+type,Property,type,"A service type, e.g., “jenkins”",Test,string
+url,Property,url,The service’s URL,Test,string
+resource,Property,resource,Relative URL of the test project on the service,Test,string
+definition,Property,definition,Metadata describing how to run the test,Test,Definition
+test_engine,Property,test_engine,The test engine to be used for this test suite,Test,Engine
+type,Property,type,"The test engine type this suite expects, e.g., “planemo”",Test,string
+version,Property,version,"The test engine version this suite expects, e.g., “>=0.70”",Test,string
+path,Property,path,Path to the engine configuration for this test suite,Test,string

--- a/test/vocabulary.csv
+++ b/test/vocabulary.csv
@@ -1,9 +1,9 @@
 term,type,label,description,domain,range
-TestSuite,Class,TestSuite,A test suite for a computational workflow,,
-TestInstance,Class,TestInstance,A specific instance of a test suite,,
-TestService,Class,TestService,A software service where tests can be run,,
-TestDefinition,Class,TestDefinition,A set of metadata that describes how to run the test,,
+TestSuite,Class,test suite,A test suite for a computational workflow,,
+TestInstance,Class,test instance,A specific instance of a test suite,,
+TestService,Class,test service,A software service where tests can be run,,
+TestDefinition,Class,test definition,A set of metadata that describes how to run the test,,
 instance,Property,instance,Instances of a test suite,TestSuite,TestInstance
-runsOn,Property,runsOn,Service where the test instance is executed,TestInstance,TestService
+runsOn,Property,runs on,Service where the test instance is executed,TestInstance,TestService
 resource,Property,resource,Relative URL of the test project on the service,TestService,string
 definition,Property,definition,Metadata describing how to run the test,TestSuite,TestDefinition

--- a/test/vocabulary.csv
+++ b/test/vocabulary.csv
@@ -1,17 +1,9 @@
 term,type,label,description,domain,range
-Test,Class,Test,A test suite for a scientific workflow,,
-Instance,Class,Instance,A specific instance of a test suite,,
-Service,Class,Service,A Continuous Integration service where tests can be run,,
-Engine,Class,Engine,A workflow testing engine,,
-Definition,Class,Definition,A test definition (engine and configuration),,
-test,Property,test,Test suites for a workflow,Test,Test
-instance,Property,instance,Instances of a test suite,Test,Instance
-service,Property,service,Service where the test is run,Test,Service
-type,Property,type,"A service type, e.g., “jenkins”",Test,string
-url,Property,url,The service’s URL,Test,string
-resource,Property,resource,Relative URL of the test project on the service,Test,string
-definition,Property,definition,Metadata describing how to run the test,Test,Definition
-test_engine,Property,test_engine,The test engine to be used for this test suite,Test,Engine
-type,Property,type,"The test engine type this suite expects, e.g., “planemo”",Test,string
-version,Property,version,"The test engine version this suite expects, e.g., “>=0.70”",Test,string
-path,Property,path,Path to the engine configuration for this test suite,Test,string
+TestSuite,Class,TestSuite,A test suite for a computational workflow,,
+TestInstance,Class,TestInstance,A specific instance of a test suite,,
+TestService,Class,TestService,A software service where tests can be run,,
+TestDefinition,Class,TestDefinition,A set of metadata that describes how to run the test,,
+instance,Property,instance,Instances of a test suite,TestSuite,TestInstance
+runsOn,Property,runsOn,Service where the test instance is executed,TestInstance,TestService
+resource,Property,resource,Relative URL of the test project on the service,TestService,string
+definition,Property,definition,Metadata describing how to run the test,TestSuite,TestDefinition


### PR DESCRIPTION
This is a first stab at defining a namespace for workflow testing, based on https://github.com/crs4/life_monitor/wiki/Test-Metadata-Draft-Spec. The main purpose is to start exploring a future possible tighter interaction of the test specs with the RO-Crate structure.

I wasn't sure about several things, but it's a starting point. This needs feedback from @stain and other experts in RO-Crate and vocabulary-based modeling.

Some doubts I had about this representation while drafting the vocabulary:

* What's the role of the domain? Is it OK to have `Test` as the domain for all properties or should an entity have its containing entity as its domain (e.g., Instance as the domain for "service")
* I tried to map the [current test metadata](https://github.com/crs4/life_monitor/wiki/Test-Metadata-Draft-Spec) specs as they are, and this resulted in duplicate names (e.g., "type"). Is that OK (and maybe should be resolved through different domains, see the above bullet point)? Or should all names be different irrespective of where they occur in the structure? My guess is that they should be different if they have different meanings as in this case (e.g., serviceType, engineType)
* Do entities that already exist in the main RO-Crate context need to be re-defined? For instance, the criminal characters example defines "Person", but that's already in the RO-Crate context. I haven't included "name" in the vocabulary for this reason.
* Should names be more domain-specific, e.g., "testInstance", "testService", or is it appropriate to use the current names since they are inside a namespace? Here my guess is that they should be more specific, since when multiple contexts are merged (the general RO-Crate one and the test-specific one in this case) all names end up being stripped of their full URI and could possibly clash with existing terms:

```json
{
  "@context": [ 
    "https://w3id.org/ro/crate/1.1-DRAFT/context",
    {"service": "https://w3id.org/ro/terms/test#service"}
  ],
  "@graph": [ ... ]
}
```

Opening as a draft PR due to its WIP / discussion status.

@ilveroluca @kikkomep