### PR TITLE
Workflow run terms

### DIFF
--- a/workflow-run/context.json
+++ b/workflow-run/context.json
@@ -1,0 +1,8 @@
+[
+    "https://w3id.org/ro/crate/1.1/context",
+    {
+        "Null": "https://w3id.org/ro/terms/workflow-run#Null",
+        "Long": "https://w3id.org/ro/terms/workflow-run#Long",
+        "Double": "https://w3id.org/ro/terms/workflow-run#Double"
+    }
+]

--- a/workflow-run/cwl_type_mapping.csv
+++ b/workflow-run/cwl_type_mapping.csv
@@ -1,0 +1,11 @@
+cwl,ro-crate,standard
+Any,Thing,true
+null,Null,false
+boolean,Boolean,true
+int,Integer,true
+long,Long,false
+float,Float,true
+double,Double,false
+string,Text,true
+File,File,true
+Directory,Dataset,true

--- a/workflow-run/cwl_type_mapping.csv
+++ b/workflow-run/cwl_type_mapping.csv
@@ -1,4 +1,4 @@
-cwl,ro-crate,standard
+cwl,ro-crate,existing
 Any,Thing,true
 null,Null,false
 boolean,Boolean,true

--- a/workflow-run/vocabulary.csv
+++ b/workflow-run/vocabulary.csv
@@ -1,0 +1,4 @@
+term,type,label,description,domain,range
+Null,Class,no value,Used to indicate a missing parameter,,
+Long,Class,long integer,64-bit signed integer,,
+Double,Class,double precision,Double precision (64-bit) floating point number,,


### PR DESCRIPTION
First version of terms for [Workflow Run RO-Crate](https://www.researchobject.org/workflow-run-crate). Contains a possible mapping from [CWL types](https://www.commonwl.org/v1.2/CommandLineTool.html) to RO-Crate types (see `cwl_type_mapping.csv`) and a vocabulary with the definition of extra terms (i.e., those that don't have a mapping in the base RO-Crate profile).
