### PR TITLE
Workflow run terms for parameter connections

### DIFF
--- a/workflow-run/context.json
+++ b/workflow-run/context.json
@@ -3,7 +3,7 @@
     {
         "ParameterConnection": "https://w3id.org/ro/terms/workflow-run#ParameterConnection",
         "connection": "https://w3id.org/ro/terms/workflow-run#connection",
-        "source": "https://w3id.org/ro/terms/workflow-run#source",
-        "target": "https://w3id.org/ro/terms/workflow-run#target"
+        "sourceParameter": "https://w3id.org/ro/terms/workflow-run#sourceParameter",
+        "targetParameter": "https://w3id.org/ro/terms/workflow-run#targetParameter"
     }
 ]

--- a/workflow-run/context.json
+++ b/workflow-run/context.json
@@ -1,0 +1,6 @@
+[
+    "https://w3id.org/ro/crate/1.1/context",
+    {
+        "executedStep": "https://w3id.org/ro/terms/workflow-run#executedStep"
+    }
+]

--- a/workflow-run/context.json
+++ b/workflow-run/context.json
@@ -1,6 +1,9 @@
 [
     "https://w3id.org/ro/crate/1.1/context",
     {
-        "executedStep": "https://w3id.org/ro/terms/workflow-run#executedStep"
+        "ParameterConnection": "https://w3id.org/ro/terms/workflow-run#ParameterConnection",
+        "connection": "https://w3id.org/ro/terms/workflow-run#connection",
+        "source": "https://w3id.org/ro/terms/workflow-run#source",
+        "target": "https://w3id.org/ro/terms/workflow-run#target"
     }
 ]

--- a/workflow-run/readme.md
+++ b/workflow-run/readme.md
@@ -1,0 +1,6 @@
+### Workflow run namespace
+
+Additional terms for the [Workflow Run RO-Crate](https://www.researchobject.org/workflow-run-crate/) profile.
+
+Maintainer:
+- The [Workflow Run RO-Crate](https://www.researchobject.org/workflow-run-crate/) working group

--- a/workflow-run/vocabulary.csv
+++ b/workflow-run/vocabulary.csv
@@ -1,0 +1,2 @@
+"term","type","label","description","domain","range"
+"executedStep","Property","executedStep","An action that represents a partial execution of this action.","Action","Action"

--- a/workflow-run/vocabulary.csv
+++ b/workflow-run/vocabulary.csv
@@ -1,5 +1,5 @@
 "term","type","label","description","domain","range"
 "ParameterConnection","Class","ParameterConnection","A connection between parameters of different applications",,
 "connection","Property","connection","A parameter connection created by this workflow","ComputationalWorkflow","ParameterConnection"
-"source","Property","source","The source (upstream) parameter","ParameterConnection","FormalParameter"
-"target","Property","target","The target (downstream) parameter","ParameterConnection","FormalParameter"
+"sourceParameter","Property","sourceParameter","The source (upstream) parameter","ParameterConnection","FormalParameter"
+"targetParameter","Property","targetParameter","The target (downstream) parameter","ParameterConnection","FormalParameter"

--- a/workflow-run/vocabulary.csv
+++ b/workflow-run/vocabulary.csv
@@ -1,2 +1,5 @@
 "term","type","label","description","domain","range"
-"executedStep","Property","executedStep","An action that represents a partial execution of this action.","Action","Action"
+"ParameterConnection","Class","ParameterConnection","A connection between parameters of different applications",,
+"connection","Property","connection","A parameter connection created by this workflow","ComputationalWorkflow","ParameterConnection"
+"source","Property","source","The source (upstream) parameter","ParameterConnection","FormalParameter"
+"target","Property","target","The target (downstream) parameter","ParameterConnection","FormalParameter"


### PR DESCRIPTION
See https://github.com/ResearchObject/workflow-run-crate/issues/25.

The idea is to use them like this:

```json
{
    "@id": "packed.cwl",
    "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow", "HowTo"],
    "hasPart": [
        {"@id": "packed.cwl#revtool.cwl"},
        {"@id": "packed.cwl#sorttool.cwl"}
    ],
    "input": [
        {"@id": "packed.cwl#main/input"},
        {"@id": "packed.cwl#main/reverse_sort"}
    ],
    "output": [
        {"@id": "packed.cwl#main/output"}
    ],
    "connection": [
        {"@id": "#pc-1"},
        ...
    ],
    ...
},
{
    "@id": "packed.cwl#revtool.cwl",
    "@type": "SoftwareApplication",
    "input": [
        {"@id": "packed.cwl#revtool.cwl/input"}
    ],
    "name": "revtool.cwl",
    "output": [
        {"@id": "packed.cwl#revtool.cwl/output"}
    ]
},
{
    "@id": "packed.cwl#main/input",
    "@type": "FormalParameter",
    "additionalType": "File"
},
{
    "@id": "packed.cwl#revtool.cwl/input",
    "@type": "FormalParameter",
    "additionalType": "File"
},
{
    "@id": "#pc-1",
    "@type": "ParameterConnection",
    "sourceParameter": {"@id": "packed.cwl#main/input"},
    "targetParameter": {"@id": "packed.cwl#revtool.cwl/input"}
}
```