### PR TITLE
Add terms for some hashing functions

### DIFF
--- a/workflow-run/context.json
+++ b/workflow-run/context.json
@@ -4,6 +4,10 @@
         "ParameterConnection": "https://w3id.org/ro/terms/workflow-run#ParameterConnection",
         "connection": "https://w3id.org/ro/terms/workflow-run#connection",
         "sourceParameter": "https://w3id.org/ro/terms/workflow-run#sourceParameter",
-        "targetParameter": "https://w3id.org/ro/terms/workflow-run#targetParameter"
+        "targetParameter": "https://w3id.org/ro/terms/workflow-run#targetParameter",
+        "md5": "https://w3id.org/ro/terms/workflow-run#md5",
+        "sha1": "https://w3id.org/ro/terms/workflow-run#sha1",
+        "sha256": "https://w3id.org/ro/terms/workflow-run#sha256",
+        "sha512": "https://w3id.org/ro/terms/workflow-run#sha512"
     }
 ]

--- a/workflow-run/vocabulary.csv
+++ b/workflow-run/vocabulary.csv
@@ -3,3 +3,7 @@
 "connection","Property","connection","A parameter connection created by this workflow","ComputationalWorkflow HowToStep","ParameterConnection"
 "sourceParameter","Property","sourceParameter","The source (upstream) parameter","ParameterConnection","FormalParameter"
 "targetParameter","Property","targetParameter","The target (downstream) parameter","ParameterConnection","FormalParameter"
+"md5","Property","md5","md5 checksum as a hexadecimal string","File","Text"
+"sha1","Property","sha1","sha1 checksum as a hexadecimal string","File","Text"
+"sha256","Property","sha256","sha256 checksum as a hexadecimal string","File","Text"
+"sha512","Property","sha512","sha512 checksum as a hexadecimal string","File","Text"


### PR DESCRIPTION
Fixes #14

I've decided to go with a small set of popular algorithms, to avoid bloating the namespace with a ton of new terms. If there is need for others that are not being added here, we can add them later. For the record, here's a list of what Python 3.10 supports:

```pycon
>>> import hashlib
>>> for s in sorted(hashlib.algorithms_available): print(s)
... 
blake2b
blake2s
md4
md5
md5-sha1
ripemd160
sha1
sha224
sha256
sha384
sha3_224
sha3_256
sha3_384
sha3_512
sha512
sha512_224
sha512_256
shake_128
shake_256
sm3
whirlpool
```