### PR TITLE
workflow-run: add softwareRequirements override

### DIFF
--- a/workflow-run/context.json
+++ b/workflow-run/context.json
@@ -16,7 +16,8 @@
             "environment": "https://w3id.org/ro/terms/workflow-run#environment",
             "registry": "https://w3id.org/ro/terms/workflow-run#registry",
             "tag": "https://w3id.org/ro/terms/workflow-run#tag",
-            "containerImage": "https://w3id.org/ro/terms/workflow-run#containerImage"
+            "containerImage": "https://w3id.org/ro/terms/workflow-run#containerImage",
+            "softwareRequirements": "https://w3id.org/ro/terms/workflow-run#softwareRequirements"
         }
     ]
 }

--- a/workflow-run/vocabulary.csv
+++ b/workflow-run/vocabulary.csv
@@ -14,3 +14,4 @@
 "registry","Property","registry","A service to register software products, such as container images","ContainerImage","Text"
 "tag","Property","tag","A tag assigned to a software product, such as a container image","ContainerImage","Text"
 "containerImage","Property","containerImage","A container image associated with this entity","CreateAction","ContainerImage URL"
+"softwareRequirements","Property","softwareRequirements","See https://schema.org/softwareRequirements","SoftwareApplication SoftwareSourceCode ComputationalWorkflow","Text URL SoftwareApplication"


### PR DESCRIPTION
Adds https://w3id.org/ro/terms/workflow-run#softwareRequirements with the same semantics as https://schema.org/softwareRequirements, but with extended domain (`SoftwareApplication`, `SoftwareSourceCode`, `ComputationalWorkflow`) and target (`Text`, `URL`, `SoftwareApplication`). See https://github.com/ResearchObject/workflow-run-crate/issues/18.