### PR TITLE
workflow-run: add resourceUsage

### DIFF
--- a/workflow-run/context.json
+++ b/workflow-run/context.json
@@ -16,7 +16,8 @@
             "environment": "https://w3id.org/ro/terms/workflow-run#environment",
             "registry": "https://w3id.org/ro/terms/workflow-run#registry",
             "tag": "https://w3id.org/ro/terms/workflow-run#tag",
-            "containerImage": "https://w3id.org/ro/terms/workflow-run#containerImage"
+            "containerImage": "https://w3id.org/ro/terms/workflow-run#containerImage",
+            "resourceUsage": "https://w3id.org/ro/terms/workflow-run#resourceUsage"
         }
     ]
 }

--- a/workflow-run/readme.md
+++ b/workflow-run/readme.md
@@ -54,3 +54,4 @@ For updates to terms, remember to:
 | registry | Property | registry | A service to register software products, such as container images | ContainerImage | Text | 
 | tag | Property | tag | A tag assigned to a software product, such as a container image | ContainerImage | Text | 
 | containerImage | Property | containerImage | A container image associated with this entity | CreateAction | ContainerImage URL |
+| resourceUsage | Property | resourceUsage | A resource usage item, such as peak memory | CreateAction | PropertyValue |

--- a/workflow-run/vocabulary.csv
+++ b/workflow-run/vocabulary.csv
@@ -14,3 +14,4 @@
 "registry","Property","registry","A service to register software products, such as container images","ContainerImage","Text"
 "tag","Property","tag","A tag assigned to a software product, such as a container image","ContainerImage","Text"
 "containerImage","Property","containerImage","A container image associated with this entity","CreateAction","ContainerImage URL"
+"resourceUsage","Property","resourceUsage","A resource usage item, such as peak memory","CreateAction","PropertyValue"

--- a/workflow-run/wfrun.jsonld
+++ b/workflow-run/wfrun.jsonld
@@ -17,7 +17,7 @@
             "registry": "https://w3id.org/ro/terms/workflow-run#registry",
             "tag": "https://w3id.org/ro/terms/workflow-run#tag",
             "containerImage": "https://w3id.org/ro/terms/workflow-run#containerImage",
-
+            "resourceUsage": "https://w3id.org/ro/terms/workflow-run#resourceUsage",
 	    "input": "https://bioschemas.org/properties/input",
 	    "output": "https://bioschemas.org/properties/output",
             "wfrun": "https://w3id.org/ro/terms/workflow-run#",
@@ -64,6 +64,9 @@
                 },
                 {
                     "@id": "wfrun:containerImage"
+                },
+                {
+                    "@id": "wfrun:resourceUsage"
                 },
                 {
                     "@id": "wfrun:md5"
@@ -394,6 +397,27 @@
             },
             "rangeIncludes": {
                 "@id": "wfrun:ContainerImage"
+            },
+            "domainIncludes": {
+                "@id": "CreateAction"
+            },
+            "@type": "rdf:Property"
+        },
+        {
+            "@id": "wfrun:resourceUsage",
+            "rdfs:comment": {
+                "@language": "en-gb",
+                "@value": "A resource usage item, such as peak memory"
+            },
+            "rdfs:label": {
+                "@language": "en-gb",
+                "@value": "resourceUsage"
+            },
+            "rdfs:isDefinedBy": {
+                "@id": "https://w3id.org/ro/terms/workflow-run#"
+            },
+            "rangeIncludes": {
+                "@id": "PropertyValue"
             },
             "domainIncludes": {
                 "@id": "CreateAction"

--- a/workflow-run/wfrun.nt
+++ b/workflow-run/wfrun.nt
@@ -43,6 +43,12 @@
 <https://w3id.org/ro/terms/workflow-run#containerImage> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/ro/terms/workflow-run#> .
 <https://w3id.org/ro/terms/workflow-run#containerImage> <http://www.w3.org/2000/01/rdf-schema#label> "containerImage"@en-gb .
 <https://w3id.org/ro/terms/workflow-run#containerImage> <http://www.w3.org/2000/01/rdf-schema#comment> "A container image associated with this entity"@en-gb .
+<https://w3id.org/ro/terms/workflow-run#resourceUsage> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<https://w3id.org/ro/terms/workflow-run#resourceUsage> <http://schema.org/domainIncludes> <http://schema.org/CreateAction> .
+<https://w3id.org/ro/terms/workflow-run#resourceUsage> <http://schema.org/rangeIncludes> <http://schema.org/PropertyValue> .
+<https://w3id.org/ro/terms/workflow-run#resourceUsage> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/ro/terms/workflow-run#> .
+<https://w3id.org/ro/terms/workflow-run#resourceUsage> <http://www.w3.org/2000/01/rdf-schema#label> "resourceUsage"@en-gb .
+<https://w3id.org/ro/terms/workflow-run#resourceUsage> <http://www.w3.org/2000/01/rdf-schema#comment> "A resource usage item, such as peak memory"@en-gb .
 <https://w3id.org/ro/terms/workflow-run#environment> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
 <https://w3id.org/ro/terms/workflow-run#environment> <http://schema.org/domainIncludes> <http://schema.org/CreateAction> .
 <https://w3id.org/ro/terms/workflow-run#environment> <http://schema.org/domainIncludes> <http://schema.org/SoftwareApplication> .

--- a/workflow-run/wfrun.rdf
+++ b/workflow-run/wfrun.rdf
@@ -61,6 +61,7 @@
     <s:hasDefinedTerm rdf:resource="https://w3id.org/ro/terms/workflow-run#sourceParameter"/>
     <s:hasDefinedTerm rdf:resource="https://w3id.org/ro/terms/workflow-run#environment"/>
     <s:hasDefinedTerm rdf:resource="https://w3id.org/ro/terms/workflow-run#containerImage"/>
+    <s:hasDefinedTerm rdf:resource="https://w3id.org/ro/terms/workflow-run#resourceUsage"/>
     <s:description>A Schema.org style Schema definitin of WRROC terms</s:description>
     <s:hasDefinedTerm rdf:resource="https://w3id.org/ro/terms/workflow-run#md5"/>
     <s:hasDefinedTerm rdf:resource="https://w3id.org/ro/terms/workflow-run#DockerImage"/>
@@ -84,6 +85,14 @@
     <rdfs:label xml:lang="en-gb">containerImage</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/ro/terms/workflow-run#"/>
     <s:rangeIncludes rdf:resource="https://w3id.org/ro/terms/workflow-run#ContainerImage"/>
+    <s:domainIncludes rdf:resource="http://schema.org/CreateAction"/>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/ro/terms/workflow-run#resourceUsage">
+    <rdfs:comment xml:lang="en-gb">A resource usage item, such as peak memory</rdfs:comment>
+    <rdfs:label xml:lang="en-gb">resourceUsage</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/ro/terms/workflow-run#"/>
+    <s:rangeIncludes rdf:resource="https://w3id.org/ro/terms/workflow-run#PropertyValue"/>
     <s:domainIncludes rdf:resource="http://schema.org/CreateAction"/>
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
   </rdf:Description>

--- a/workflow-run/wfrun.ttl
+++ b/workflow-run/wfrun.ttl
@@ -55,6 +55,13 @@ wfrun:containerImage rdf:type rdf:Property ;
                      rdfs:label "containerImage"@en-gb ;
                      rdfs:comment "A container image associated with this entity"@en-gb .
 
+wfrun:resourceUsage rdf:type rdf:Property ;
+                    s:domainIncludes s:CreateAction ;
+                    s:rangeIncludes s:PropertyValue ;
+                    rdfs:isDefinedBy wfrun: ;
+                    rdfs:label "resourceUsage"@en-gb ;
+                    rdfs:comment "A resource usage item, such as peak memory"@en-gb .
+
 wfrun:environment rdf:type rdf:Property ;
                   s:domainIncludes  s:CreateAction,
                                     s:SoftwareApplication,


### PR DESCRIPTION
See https://github.com/ResearchObject/workflow-run-crate/issues/10 for the background.

Example:

```json
{
    "@id": "#28/7f2737",
    "@type": "CreateAction",
    "instrument": {"@id": "tutorial.nf#convertToUpper"},
    "resourceUsage": [
        {
            "@id": "#28/7f2737-realTime"
        },
        {
            "@id": "#28/7f2737-percentCPU"
        }
    ]
},
{
    "@id": "#28/7f2737-realTime",
    "@type": "PropertyValue",
    "name": "realTime",
    "propertyID": "https://w3id.org/ro/terms/nf-trace#realTime",
    "unitCode": "https://qudt.org/vocab/unit/MilliSEC",
    "value": "12"
},
{
    "@id": "#28/7f2737-percentCPU",
    "@type": "PropertyValue",
    "name": "percentCPU",
    "propertyID": "https://w3id.org/ro/terms/nf-trace#percentCPU",
    "value": "80.0"
}
```