### PR TITLE
Initial custom RO-Terms needed by WfExS-backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ And if you want them in json-ld:
 
 `curl -H "accept:application/ld+json" -L https://w3id.org/ro/terms > context.json`
 
-Equuivalent content negotation is available for each of the [folders](https://github.com/ResearchObject/ro-terms/tree/master) registered under ro-terms, e.g. <https://w3id.org/ro/terms/earth-science#>
+Equivalent content negotiation is available for each of the [folders](https://github.com/ResearchObject/ro-terms/tree/master) registered under ro-terms, e.g. <https://w3id.org/ro/terms/earth-science#>
 
 ## Contribution guidelines
 This repository <https://github.com/researchobject/ro-terms> works in a first-come, first-serve basis. To add your own terms, simply:

--- a/wfexs/context.json
+++ b/wfexs/context.json
@@ -1,0 +1,10 @@
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "syntheticOutput": "https://w3id.org/ro/terms/wfexs#syntheticOutput",
+            "globPattern": "https://w3id.org/ro/terms/wfexs#globPattern",
+            "filledFrom": "https://w3id.org/ro/terms/wfexs#filledFrom"
+        }
+    ]
+}

--- a/wfexs/readme.md
+++ b/wfexs/readme.md
@@ -1,0 +1,8 @@
+### WfExS namespace
+
+Namespace which includes terms needed by [WfExS-backend](https://github.com/inab/WfExS-backend)
+to describe specific features it implements, like synthetic outputs,
+used glob patterns, input tabular parsing, etc...
+
+Maintainer: 
+- José Mª Fernández (@jmfernandez)

--- a/wfexs/vocabulary.csv
+++ b/wfexs/vocabulary.csv
@@ -1,4 +1,4 @@
 term,type,label,description,domain,range
 syntheticOutput,Property,"synthetic output","Is the related output File, Dataset or Collection 'synthetic'? (i.e. obtained using a glob pattern from other output)","FormalParameter","Boolean"
 globPattern,Property,"glob pattern","Glob pattern used to select the components of this 'synthetic' output File, Dataset or Collection","FormalParameter","Text"
-filledFrom, Property,"filled from","This output was (partially) fed from another output","FormalParameter","FormalParameter"
+filledFrom, Property,"filled from","The path of this output was either setup through this parameter, or it is (partially) fed from another output","FormalParameter","Text"

--- a/wfexs/vocabulary.csv
+++ b/wfexs/vocabulary.csv
@@ -1,0 +1,4 @@
+term,type,label,description,domain,range
+syntheticOutput,Property,"synthetic output","Is the related output File, Dataset or Collection 'synthetic'? (i.e. obtained using a glob pattern from other output)","FormalParameter","Boolean"
+globPattern,Property,"glob pattern","Glob pattern used to select the components of this 'synthetic' output File, Dataset or Collection","FormalParameter","Text"
+filledFrom, Property,"filled from","This output was (partially) fed from another output","FormalParameter","FormalParameter"


### PR DESCRIPTION
Generated RO-Crates from WfExS-backend needed to include some hints which help on RO-Crates generated from Nextflow workflow executions, and so these terms were created in order to model them.