### PR TITLE
Add provstor terms for cp and mv

### DIFF
--- a/provstor/context.json
+++ b/provstor/context.json
@@ -1,0 +1,6 @@
+{
+    "@context": {
+        "CopyTool": "https://w3id.org/ro/terms/provstor#CopyTool",
+        "MoveTool": "https://w3id.org/ro/terms/provstor#MoveTool"
+    }
+}

--- a/provstor/context.jsonld
+++ b/provstor/context.jsonld
@@ -1,0 +1,6 @@
+{
+    "@context": {
+        "CopyTool": "https://w3id.org/ro/terms/provstor#CopyTool",
+        "MoveTool": "https://w3id.org/ro/terms/provstor#MoveTool"
+    }
+}

--- a/provstor/readme.md
+++ b/provstor/readme.md
@@ -1,0 +1,6 @@
+### Provstor namespace
+
+A namespace for terms used by [provstor](https://github.com/crs4/provenance-storage).
+
+Maintainer:
+- Simone Leo (@simleo)

--- a/provstor/vocabulary.csv
+++ b/provstor/vocabulary.csv
@@ -1,0 +1,3 @@
+"term","type","label","description","domain","range"
+"CopyTool","Class","CopyTool","https://www.gnu.org/software/coreutils/ cp",,
+"MoveTool","Class","MoveTool","https://www.gnu.org/software/coreutils/ mv",,


### PR DESCRIPTION
`CopyTool` and `MoveTool` represent the `cp` and `mv` commands from [GNU Coreutils](https://www.gnu.org/software/coreutils/).

See https://github.com/crs4/provenance-storage/pull/25.