### PR TITLE
New metrics about GPU usage added to COMPSs vocabulary

### DIFF
--- a/compss/context.json
+++ b/compss/context.json
@@ -13,6 +13,11 @@
         "byteSent": "https://w3id.org/ro/terms/compss#byteSent",
         "byteRecv": "https://w3id.org/ro/terms/compss#byteRecv",
         "byteRead": "https://w3id.org/ro/terms/compss#byteRead",
-        "byteWritten": "https://w3id.org/ro/terms/compss#byteWritten"
+        "byteWritten": "https://w3id.org/ro/terms/compss#byteWritten",
+        "gpuAvg": "https://w3id.org/ro/terms/compss#gpuAvg",
+        "gpuMax": "https://w3id.org/ro/terms/compss#gpuMax",
+        "gpuMemAvg": "https://w3id.org/ro/terms/compss#gpuMemAvg",
+        "gpuMemMax": "https://w3id.org/ro/terms/compss#gpuMemMax",
+        "gpuMemMin": "https://w3id.org/ro/terms/compss#gpuMemMin"
     }
 }

--- a/compss/context.jsonld
+++ b/compss/context.jsonld
@@ -13,6 +13,11 @@
         "byteSent": "https://w3id.org/ro/terms/compss#byteSent",
         "byteRecv": "https://w3id.org/ro/terms/compss#byteRecv",
         "byteRead": "https://w3id.org/ro/terms/compss#byteRead",
-        "byteWritten": "https://w3id.org/ro/terms/compss#byteWritten"
+        "byteWritten": "https://w3id.org/ro/terms/compss#byteWritten",
+        "gpuAvg": "https://w3id.org/ro/terms/compss#gpuAvg",
+        "gpuMax": "https://w3id.org/ro/terms/compss#gpuMax",
+        "gpuMemAvg": "https://w3id.org/ro/terms/compss#gpuMemAvg",
+        "gpuMemMax": "https://w3id.org/ro/terms/compss#gpuMemMax",
+        "gpuMemMin": "https://w3id.org/ro/terms/compss#gpuMemMin"
     }
 }

--- a/compss/vocabulary.csv
+++ b/compss/vocabulary.csv
@@ -13,3 +13,8 @@ byteSent,Property,byteSent,"Total bytes sent during the execution",ResourceUsage
 byteRecv,Property,byteRecv,"Total bytes received during the execution",ResourceUsage,Integer
 byteRead,Property,byteRead,"Total bytes read from disk during the execution",ResourceUsage,Integer
 byteWritten,Property,byteWritten,"Total bytes written to disk during the execution",ResourceUsage,Integer
+gpuAvg,Property,gpuAvg,"Average GPU usage percentage recorded during the execution",ResourceUsage,Float
+gpuMax,Property,gpuMax,"Maximum GPU usage percentage recorded during the execution",ResourceUsage,Float
+gpuMemAvg,Property,gpuMemAvg,"Average GPU memory usage percentage recorded during the execution",ResourceUsage,Float
+gpuMemMax,Property,gpuMemMax,"Maximum GPU memory usage percentage recorded during the execution",ResourceUsage,Float
+gpuMemMin,Property,gpuMemMin,"Minimum GPU memory usage percentage recorded during the execution",ResourceUsage,Float


### PR DESCRIPTION
This pull request adds new properties to track GPU usage statistics in the `ResourceUsage` vocabulary. These additions will allow the system to monitor both GPU utilization and GPU memory usage during execution.
Added `gpuAvg`, `gpuMax`, `gpuMemAvg`, `gpuMemMax`, and `gpuMemMin` properties to record average and maximum GPU usage, as well as average, maximum, and minimum GPU memory usage percentages.